### PR TITLE
Switch bin/server of browser to support python3

### DIFF
--- a/inst/dfb/bin/server
+++ b/inst/dfb/bin/server
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python -m SimpleHTTPServer 8888
+python3 -m http.server 8888


### PR DESCRIPTION
Per the associated [python docs](https://docs.python.org/2/library/simplehttpserver.html), SimpleHTTPServer was merged with http.server in python3. As Python2 is EOL, this switches to python3 support for the browser server script.